### PR TITLE
Minor fixes after first workshop

### DIFF
--- a/00_intro.qmd
+++ b/00_intro.qmd
@@ -274,6 +274,7 @@ Source: [RStudio - Markdown basics](https://quarto.org/docs/authoring/markdown-b
 
 ## Specials {.center}
 
+::: {.nonincremental}
 +------------------+----------------+
 | Markdown Syntax  | Output         |
 +==================+================+
@@ -285,6 +286,7 @@ Source: [RStudio - Markdown basics](https://quarto.org/docs/authoring/markdown-b
 |     : definition |                |
 |                  | :   definition |
 +------------------+----------------+
+:::
 
 ::: footer
 Source: [RStudio - Markdown basics](https://quarto.org/docs/authoring/markdown-basics.html)

--- a/00_intro.qmd
+++ b/00_intro.qmd
@@ -274,17 +274,17 @@ Source: [RStudio - Markdown basics](https://quarto.org/docs/authoring/markdown-b
 
 ## Specials {.center}
 
-+------------------+-----------------+
-| Markdown Syntax  | Output          |
-+==================+=================+
-|     endash: --   | endash: --      |
-+------------------+-----------------+
-|     emdash: ---  | emdash: ---     |
-+------------------+-----------------+
-|     term         | term            |
-|     : definition |                 |
-|                  | :   definition  |
-+------------------+-----------------+
++------------------+----------------+
+| Markdown Syntax  | Output         |
++==================+================+
+|     endash: --   | endash: --     |
++------------------+----------------+
+|     emdash: ---  | emdash: ---    |
++------------------+----------------+
+|     term         | term           |
+|     : definition |                |
+|                  | :   definition |
++------------------+----------------+
 
 ::: footer
 Source: [RStudio - Markdown basics](https://quarto.org/docs/authoring/markdown-basics.html)

--- a/00_intro.qmd
+++ b/00_intro.qmd
@@ -156,17 +156,19 @@ Source: [RStudio - Markdown basics](https://quarto.org/docs/authoring/markdown-b
 
 ## Lists {.center}
 
-+------------------------------+-----------------------------+
-| Markdown Syntax              | Output                      |
-+==============================+=============================+
-|     * unordered list         | -   unordered list          |
-|         + sub-item 1         |                             |
-|         + sub-item 2         |     -   sub-item 1          |
-|             - sub-sub-item 1 |                             |
-|                              |     -   sub-item 2          |
-|                              |                             |
-|                              |         -   sub-sub-item 1  |
-+------------------------------+-----------------------------+
+::: {.nonincremental}
++------------------------------+----------------------------+
+| Markdown Syntax              | Output                     |
++==============================+============================+
+|     * unordered list         | -   unordered list         |
+|         + sub-item 1         |                            |
+|         + sub-item 2         |     -   sub-item 1         |
+|             - sub-sub-item 1 |                            |
+|                              |     -   sub-item 2         |
+|                              |                            |
+|                              |         -   sub-sub-item 1 |
++------------------------------+----------------------------+
+:::
 
 ::: footer
 Source: [RStudio - Markdown basics](https://quarto.org/docs/authoring/markdown-basics.html)
@@ -174,6 +176,7 @@ Source: [RStudio - Markdown basics](https://quarto.org/docs/authoring/markdown-b
 
 ## Lists {.center}
 
+::: {.nonincremental}
 +---------------------------------+----------------------------+
 | Markdown Syntax                 | Output                     |
 +=================================+============================+
@@ -185,6 +188,7 @@ Source: [RStudio - Markdown basics](https://quarto.org/docs/authoring/markdown-b
 |                                 |                            |
 |                                 |         A.  sub-sub-item 1 |
 +---------------------------------+----------------------------+
+:::
 
 ::: footer
 Source: [RStudio - Markdown basics](https://quarto.org/docs/authoring/markdown-basics.html)

--- a/01_presentation.qmd
+++ b/01_presentation.qmd
@@ -114,7 +114,7 @@ A bracketed sequence of inlines, as one would use to begin a link, will be treat
 
 -   Style documents with css (cascading style sheets)
 
--   Particulaly useful with divs and spans for special styling
+-   Particularly useful with divs and spans for special styling
 
 -   See the Pandoc documentation on [Divs and Spans](https://pandoc.org/MANUAL.html#divs-and-spans) for additional details.
 


### PR DESCRIPTION
Hey @drmowinckels,

thank you so much for this fantastic workshop! ✨ 

During the workshop, I experimented a bit with your Quarto materials (to get a sense for the source code behind your great materials). Playing around with the code of `00_intro.qmd` and `01_presentation.qmd` I "fixed" two very minor in the source code of the slides:

1. `00_intro.qmd`: You mentioned during the workshop that since you used a [global setting for incremental lists](https://github.com/drmowinckels/quartaki/blob/main/00_intro.qmd#L9) the slide on [Markdown lists](https://github.com/drmowinckels/quartaki/blob/main/00_intro.qmd#L157-L187) will also show up incrementally, although this was not intended in this case. I was curious and played around with it and found that wrapping `::: {.nonincremental}` around the Markdown tables fixes this. see commits 7527eae9551523617f4c958279292a9053be65fc and 60f32da205444aaf3aab739ef898f87d561f19dc
1. Minor typo fixes. see b0faa53485e9524841bc7e06e691c00e9621e74c (`01_presentation.qmd`)

hope this is useful! and thank you again so much for the great workshop!